### PR TITLE
use keccak hash function; match equality functionality of previous im…

### DIFF
--- a/toolbox/src/hash.rs
+++ b/toolbox/src/hash.rs
@@ -1,9 +1,9 @@
-use anchor_lang::solana_program::blake3::hashv;
+use anchor_lang::solana_program::keccak::hashv;
 
 pub fn validate_proof(root: &[u8; 32], leaf: &[u8; 32], proof: &[[u8; 32]]) -> bool {
     let mut path = *leaf;
     proof.iter().for_each(|sibling| {
-        path = if path < *sibling {
+        path = if path <= *sibling {
             hashv(&[&path, sibling]).0
         } else {
             hashv(&[sibling, &path]).0


### PR DESCRIPTION
Previous implementation uses `keccak` instead of `blake3` and programs use `keccak` as well. In addition, use the same equality operator as previous implementation for consistency.