### PR TITLE
add fee sharding macro

### DIFF
--- a/toolbox/src/common.rs
+++ b/toolbox/src/common.rs
@@ -32,7 +32,7 @@ pub mod escrow {
 #[macro_export]
 macro_rules! shard_num {
     ($account_info:expr) => {
-        &$account_info.key()[31].to_le_bytes()
+        &$account_info.key().as_ref()[31].to_le_bytes()
     };
     ($pubkey:expr) => {
         &$pubkey.as_ref()[31].to_le_bytes()


### PR DESCRIPTION
* Adds fee shard macro to avoid duplicating the macro in every program that uses it
* Makes the `TransferArgs` accounts `token_metadata` and `sysvar_instruction` optional since they aren't use in legacy transfers