### PR TITLE
add pubkey const fn; remove solana-program dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
+name = "five8_const"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94474d15a76982be62ca8a39570dccce148d98c238ebb7408b0a21b2c4bdddc4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,10 +2415,10 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "bytemuck",
+ "five8_const",
  "mpl-bubblegum",
  "mpl-core",
  "mpl-token-metadata",
- "solana-program",
  "spl-account-compression",
  "spl-noop",
  "spl-token-metadata-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f2a3e1df4685f18d12a943a9f2a7456305401af21a07c9fe076ef9ecd6e400"
 dependencies = [
  "anchor-syn",
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -221,7 +221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9101b84702fed2ea57bd22992f75065da5648017135b844283a2f6d74f27825"
 dependencies = [
  "anyhow",
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "heck",
  "proc-macro2",
  "quote",
@@ -584,9 +584,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
 ]

--- a/toolbox/Cargo.toml
+++ b/toolbox/Cargo.toml
@@ -17,10 +17,10 @@ token-2022 = []
 anchor-lang = "0.29.0"
 anchor-spl = { version = "0.29.0", features = ["default"] }
 bytemuck = "1.14"
+five8_const = "0.1.3"
 mpl-bubblegum = { version = "1.4.0", optional = true }
 mpl-core = { version = "0.7.2", optional = true }
 mpl-token-metadata = "4.0.0"
-solana-program = "^1.14, <1.19"
 spl-account-compression = { version = "0.3.0", features = ["cpi"] }
 spl-noop = { version = "0.2.0", features = ["no-entrypoint"] }
 spl-token-metadata-interface = "0.2.0"

--- a/toolbox/src/common.rs
+++ b/toolbox/src/common.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::result_large_err)]
-
 use anchor_lang::{
     prelude::*,
-    solana_program::{program::invoke, system_instruction, system_program},
+    solana_program::{program::invoke, pubkey::Pubkey, system_instruction, system_program},
 };
 use anchor_spl::{associated_token::AssociatedToken, token_interface::TokenInterface};
 use mpl_token_metadata::types::TokenStandard;
-use solana_program::pubkey;
 use std::slice::Iter;
 use tensor_vipers::prelude::*;
 
@@ -19,11 +17,15 @@ pub const TNSR_DISCOUNT_BPS: u64 = 2500;
 pub const TAKER_FEE_BPS: u64 = 200;
 pub const MAKER_BROKER_PCT: u64 = 80; // Out of 100
 
+pub const fn pubkey(base58str: &str) -> Pubkey {
+    Pubkey::new_from_array(five8_const::decode_32_const(base58str))
+}
+
 pub mod escrow {
     use super::*;
     declare_id!("TSWAPaqyCSx2KABk68Shruf4rp7CxcNi8hAsbdwmHbN");
 
-    pub const TSWAP_SINGLETON: Pubkey = pubkey!("4zdNGgAtFsW1cQgHqkiWyRsxaAgxrSRRynnuunxzjxue");
+    pub const TSWAP_SINGLETON: Pubkey = pubkey("4zdNGgAtFsW1cQgHqkiWyRsxaAgxrSRRynnuunxzjxue");
 }
 
 pub mod fees {
@@ -35,7 +37,7 @@ pub mod marketplace {
     use super::*;
     declare_id!("TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp");
 
-    pub const TCOMP_SINGLETON: Pubkey = pubkey!("q4s8z5dRAt2fKC2tLthBPatakZRXPMx1LfacckSXd4f");
+    pub const TCOMP_SINGLETON: Pubkey = pubkey("q4s8z5dRAt2fKC2tLthBPatakZRXPMx1LfacckSXd4f");
 }
 
 pub mod mpl_token_auth_rules {
@@ -47,7 +49,7 @@ pub mod price_lock {
     use super::*;
     declare_id!("TLoCKic2wGJm7VhZKumih4Lc35fUhYqVMgA4j389Buk");
 
-    pub const TLOCK_SINGLETON: Pubkey = pubkey!("CdXA5Vpg4hqvsmLSKC2cygnJVvsQTrDrrn428nAZQaKz");
+    pub const TLOCK_SINGLETON: Pubkey = pubkey("CdXA5Vpg4hqvsmLSKC2cygnJVvsQTrDrrn428nAZQaKz");
 }
 
 /// Calculates fee vault shard from a given AccountInfo or Pubkey. Relies on the Anchor `Key` trait.

--- a/toolbox/src/common.rs
+++ b/toolbox/src/common.rs
@@ -462,3 +462,41 @@ pub fn assert_fee_account(fee_vault_info: &AccountInfo, state_info: &AccountInfo
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pubkey_constant() {
+        let default_pubkey = pubkey("11111111111111111111111111111111");
+        assert_eq!(default_pubkey, Pubkey::default());
+
+        let p = pubkey("4zdNGgAtFsW1cQgHqkiWyRsxaAgxrSRRynnuunxzjxue");
+        assert_eq!(
+            p.to_bytes(),
+            [
+                59, 86, 73, 113, 118, 186, 131, 166, 77, 161, 204, 243, 144, 62, 8, 138, 52, 116,
+                86, 213, 41, 159, 32, 94, 252, 208, 28, 78, 220, 101, 76, 105
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn pubkey_constant_base58_too_short() {
+        let _p = pubkey("abc");
+    }
+
+    #[test]
+    #[should_panic]
+    fn pubkey_constant_base58_too_long() {
+        let _p = pubkey("abc123456789012345678901234567890123456789012345678901234567890123");
+    }
+
+    #[test]
+    #[should_panic]
+    fn pubkey_constant_base58_empty() {
+        let _p = pubkey("");
+    }
+}


### PR DESCRIPTION
Adds a constant function `pubkey` to `toolbox` that allows generating a `Pubkey` constant from a base58 string. This allows our Anchor programs to create constants like:

```rust
const MPL_TOKEN_AUTH_RULES_PROGRAM_ID: Pubkey = pubkey("auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg");
```

without importing the `pubkey` macro from `solana-program` directly (it's not exported as part of the Anchor re-export of the library). 